### PR TITLE
Add STUD/AbilityInfo (incomplete)

### DIFF
--- a/OWLib/OWLib.csproj
+++ b/OWLib/OWLib.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Types\Chunk\TCFE\NECE.cs" />
     <Compile Include="Types\Map\Map11.cs" />
     <Compile Include="Types\Marshal.cs" />
+    <Compile Include="Types\STUD\AbilityInfo.cs" />
     <Compile Include="Types\STUD\BrawlName.cs" />
     <Compile Include="Types\STUD\GameMode.cs" />
     <Compile Include="Types\STUD\GameTypeParam.cs" />

--- a/OWLib/Types/STUD/AbilityInfo.cs
+++ b/OWLib/Types/STUD/AbilityInfo.cs
@@ -1,0 +1,42 @@
+﻿using System.IO;
+using System.Runtime.InteropServices;
+
+namespace OWLib.Types.STUD {
+    [System.Diagnostics.DebuggerDisplay(OWLib.STUD.STUD_DEBUG_STR)]
+    public class AbilityInfo : ISTUDInstance {
+        public uint Id => 0x54024AFC;
+        public string Name => "AbilityInfo";
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct AbilityInfoData {
+            public STUDInstanceInfo instance;
+            public OWRecord name;  // 07C string
+            public OWRecord description;  // 07C string
+            public OWRecord unk1;  // 096 System Mapping
+            public ulong unk2;  // needs verifing
+            public uint unk3;  // needs verifing
+            public uint unk4;  // needs verifing
+            public OWRecord image;  // 004; display image
+            public OWRecord video;  // 0B6 Bink Video; tutorial video
+            // more data here, not sure what
+
+            // data that I presume is stored here, but I haven't found yet: type (passive, ultimate, normal)
+
+            // trial data:
+            // public ulong unk5;
+            // public uint unk6;
+            // public uint unk7;
+            // public uint unk8;
+            // public OWRecord unk9;
+        }
+
+        private AbilityInfoData data;
+        public AbilityInfoData Data => data;
+
+        public void Read(Stream input, OWLib.STUD stud) {
+            using (BinaryReader reader = new BinaryReader(input, System.Text.Encoding.Default, true)) {
+                data = reader.Read<AbilityInfoData>();
+            }
+        }
+    }
+}

--- a/OverTool/List/ListAbilityInfo.cs
+++ b/OverTool/List/ListAbilityInfo.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using CASCExplorer;
+using OWLib;
+using OWLib.Types.STUD;
+
+namespace OverTool.List {
+    public class ListAbilityInfo : IOvertool {
+        public string Title => "List Abilities";
+        public char Opt => ' ';
+        public string FullOpt => "list-abilities";
+        public string Help => "No additional arguments";
+        public uint MinimumArgs => 0;
+        public ushort[] Track => new ushort[1] { 0x9E };
+        public bool Display => true;
+
+        public void Parse(Dictionary<ushort, List<ulong>> track, Dictionary<ulong, Record> map, CASCHandler handler, bool quiet, OverToolFlags flags) {
+            foreach (ulong key in track[0x9E]) {
+                if (!map.ContainsKey(key)) {
+                    continue;
+                }
+                using (Stream input = Util.OpenFile(map[key], handler)) {
+                    if (input == null) {
+                        continue;
+                    }
+                    STUD stud = new STUD(input);
+                    if (stud.Instances == null || stud.Instances[0] == null) {
+                        continue;
+                    }
+
+                    AbilityInfo bn = stud.Instances[0] as AbilityInfo;
+                    if (bn == null) {
+                        continue;
+                    }
+                    Console.Out.WriteLine(Util.GetString(bn.Data.name, map, handler));
+                    string description = Util.GetString(bn.Data.description, map, handler);
+                    if (description != null) {
+                        Console.Out.WriteLine("\t{0}", description);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/OverTool/OverTool.csproj
+++ b/OverTool/OverTool.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Flags\FlagParser.cs" />
     <Compile Include="Flags\ICLIFlags.cs" />
     <Compile Include="IOvertool.cs" />
+    <Compile Include="List\ListAbilityInfo.cs" />
     <Compile Include="List\ListBrawlName.cs" />
     <Compile Include="List\ListGameMode.cs" />
     <Compile Include="List\ListGameType.cs" />


### PR DESCRIPTION
Adds STUD/AbilityInfo.

Incomplete because there is more data that I haven't figured out yet. 

Is there any particular best practice for figuring out which type to use where? My current method is guessing, and then trying to align the data to make OWRecords. `unk2`, `unk3` and `unk4` probably aren't right, but they align `image` and `video` correctly. (`unk4` is always 18446744073709551615, `unk3` and `unk4` are always 0)