### PR TITLE
Add STUHashTool

### DIFF
--- a/OverwatchToolchain.sln
+++ b/OverwatchToolchain.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OWLib", "OWLib\OWLib.csproj", "{353C0D05-C505-4DF4-909E-624FD94A7D3B}"
 EndProject
@@ -46,6 +46,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OWReplayLib", "OWReplayLib\OWReplayLib.csproj", "{D3747A31-85D2-424F-9865-A83245FDB762}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "STULib", "STULib\STULib.csproj", "{996012B0-3693-4642-AC44-5AA8865EE44A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "STUHashTool", "STUHashTool\STUHashTool.csproj", "{FB874758-AB99-4526-A035-8E6DA1252822}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -105,6 +107,10 @@ Global
 		{996012B0-3693-4642-AC44-5AA8865EE44A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{996012B0-3693-4642-AC44-5AA8865EE44A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{996012B0-3693-4642-AC44-5AA8865EE44A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB874758-AB99-4526-A035-8E6DA1252822}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB874758-AB99-4526-A035-8E6DA1252822}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB874758-AB99-4526-A035-8E6DA1252822}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB874758-AB99-4526-A035-8E6DA1252822}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -120,6 +126,7 @@ Global
 		{32750FDA-CFE6-4296-BE7A-27E94FB4EEFA} = {97878F88-59A9-47BD-BAA4-7B4DEAC97826}
 		{CB208F91-B1E8-4319-B4C0-2F4E15A4BFBC} = {3D7A76E0-ADD8-4F3C-8BE6-DF54FCB0CBCA}
 		{85502A7B-1B1B-4A02-B37F-11600B6194FD} = {3D7A76E0-ADD8-4F3C-8BE6-DF54FCB0CBCA}
+		{FB874758-AB99-4526-A035-8E6DA1252822} = {97878F88-59A9-47BD-BAA4-7B4DEAC97826}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/STUHashTool/App.config
+++ b/STUHashTool/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+    </startup>
+</configuration>

--- a/STUHashTool/Program.cs
+++ b/STUHashTool/Program.cs
@@ -9,7 +9,7 @@ using System.Linq;
 namespace STUHashTool {
     public class InstanceTally {
         public uint count;
-        public Dictionary<uint, uint> fieldOccurances;
+        public Dictionary<uint, uint> fieldOccurrences;
         public Dictionary<uint, List<CompareResult>> resultDict;
         public Dictionary<uint, List<FieldResult>> fieldDict;
 
@@ -62,16 +62,16 @@ namespace STUHashTool {
         }
 
         static void Main(string[] args) {
-            // usage:
-            // single file: file {before file path} {after file path}
-            // iter files in dir: dir {before file directory} {after file directory}
+            // Usage:
+            // Single file: "file {before file} {after file}"
+            // Iter files in a single directory: "dir {before files directory} {after files directory}"
 
             // todo: cleanup
 
             if (args.Length < 3) {
-                Console.Out.WriteLine("usage:");
-                Console.Out.WriteLine("single file: file {before file path} {after file path}");
-                Console.Out.WriteLine("iter files in dir: dir {before file directory} {after file directory}");
+                Console.Out.WriteLine("Usage:");
+                Console.Out.WriteLine("Single file: \"file {before file} {after file}\"");
+                Console.Out.WriteLine("Iter files in a single directory: \"dir {before files directory} {after files directory}\"");
                 return;
             }
             List<string> files1 = new List<string>();
@@ -174,10 +174,10 @@ namespace STUHashTool {
                 if (!instanceChangeTally.ContainsKey(result.beforeInstanceHash)) {
                     instanceChangeTally[result.beforeInstanceHash] = new InstanceTally { count = 1, resultDict = new Dictionary<uint, List<CompareResult>>(), fieldDict = new Dictionary<uint, List<FieldResult>>() };
                     instanceChangeTally[result.beforeInstanceHash].resultDict[result.afterInstanceHash] = new List<CompareResult> { result };
-                    instanceChangeTally[result.beforeInstanceHash].fieldOccurances = new Dictionary<uint, uint>();
+                    instanceChangeTally[result.beforeInstanceHash].fieldOccurrences = new Dictionary<uint, uint>();
                     foreach (FieldCompareResult d in result.fields) {
                         if (instanceChangeTally[result.beforeInstanceHash].fieldDict.ContainsKey(d.beforeFieldHash)) {
-                            instanceChangeTally[result.beforeInstanceHash].fieldOccurances[d.beforeFieldHash]++;
+                            instanceChangeTally[result.beforeInstanceHash].fieldOccurrences[d.beforeFieldHash]++;
                             FieldResult f = instanceChangeTally[result.beforeInstanceHash].getField(d.beforeFieldHash, d.afterFieldHash);
                             if (f != null) {
                                 f.count++;
@@ -188,7 +188,7 @@ namespace STUHashTool {
                         } else {
                             instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash] = new List<FieldResult>();
                             instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash].Add(new FieldResult { beforeFieldHash = d.beforeFieldHash, afterFieldHash = d.afterFieldHash, count = 1 });
-                            instanceChangeTally[result.beforeInstanceHash].fieldOccurances[d.beforeFieldHash] = 1;
+                            instanceChangeTally[result.beforeInstanceHash].fieldOccurrences[d.beforeFieldHash] = 1;
                         }
                     }
                 } else {
@@ -200,7 +200,7 @@ namespace STUHashTool {
 
                     foreach (FieldCompareResult d in result.fields) {
                         if (instanceChangeTally[result.beforeInstanceHash].fieldDict.ContainsKey(d.beforeFieldHash)) {
-                            instanceChangeTally[result.beforeInstanceHash].fieldOccurances[d.beforeFieldHash]++;
+                            instanceChangeTally[result.beforeInstanceHash].fieldOccurrences[d.beforeFieldHash]++;
                             FieldResult f = instanceChangeTally[result.beforeInstanceHash].getField(d.beforeFieldHash, d.afterFieldHash);
                             if (f != null) {
                                 f.count++;
@@ -211,7 +211,7 @@ namespace STUHashTool {
                         } else {
                             instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash] = new List<FieldResult>();
                             instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash].Add(new FieldResult { beforeFieldHash = d.beforeFieldHash, afterFieldHash = d.afterFieldHash, count = 1 });
-                            instanceChangeTally[result.beforeInstanceHash].fieldOccurances[d.beforeFieldHash] = 1;
+                            instanceChangeTally[result.beforeInstanceHash].fieldOccurrences[d.beforeFieldHash] = 1;
                         }
                     }
                 }
@@ -222,7 +222,7 @@ namespace STUHashTool {
                     Console.Out.WriteLine($"{it.Key:X} => {id.Key:X} ({instanceProbablility}% probability)");
                     foreach (KeyValuePair<uint, List<FieldResult>> field in it.Value.fieldDict) {
                         foreach (FieldResult fieldResult in field.Value) {
-                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X} => {fieldResult.afterFieldHash:X} ({(double)fieldResult.count / it.Value.fieldOccurances[fieldResult.beforeFieldHash] * 100:0.0#}% probability)");
+                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X} => {fieldResult.afterFieldHash:X} ({(double)fieldResult.count / it.Value.fieldOccurrences[fieldResult.beforeFieldHash] * 100:0.0#}% probability)");
                         }
                     }
                 }

--- a/STUHashTool/Program.cs
+++ b/STUHashTool/Program.cs
@@ -218,11 +218,12 @@ namespace STUHashTool {
             }
             foreach (KeyValuePair<uint, InstanceTally> it in instanceChangeTally) {
                 foreach (KeyValuePair<uint, List<CompareResult>> id in it.Value.resultDict) {
-                    double instanceProbablility = id.Value.Count / it.Value.count * 100;
-                    Console.Out.WriteLine($"{it.Key:X8} => {id.Key:X8} ({instanceProbablility}% probability)");
+                    double instanceProbablility = (double)id.Value.Count / it.Value.count * 100;
+                    Console.Out.WriteLine($"{it.Key:X8} => {id.Key:X8} ({instanceProbablility:0.0#}% probability)");
                     foreach (KeyValuePair<uint, List<FieldResult>> field in it.Value.fieldDict) {
                         foreach (FieldResult fieldResult in field.Value) {
-                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X8} => {fieldResult.afterFieldHash:X8} ({(double)fieldResult.count / it.Value.fieldOccurrences[fieldResult.beforeFieldHash] * 100:0.0#}% probability)");
+                            double fieldProbability = (double)fieldResult.count / it.Value.fieldOccurrences[fieldResult.beforeFieldHash] * 100;
+                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X8} => {fieldResult.afterFieldHash:X8} ({fieldProbability:0.0#}% probability)");
                         }
                     }
                 }

--- a/STUHashTool/Program.cs
+++ b/STUHashTool/Program.cs
@@ -222,7 +222,7 @@ namespace STUHashTool {
                     Console.Out.WriteLine($"{it.Key:X8} => {id.Key:X8} ({instanceProbablility}% probability)");
                     foreach (KeyValuePair<uint, List<FieldResult>> field in it.Value.fieldDict) {
                         foreach (FieldResult fieldResult in field.Value) {
-                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X8} => {fieldResult.afterFieldHash:X:X8} ({(double)fieldResult.count / it.Value.fieldOccurrences[fieldResult.beforeFieldHash] * 100:0.0#}% probability)");
+                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X8} => {fieldResult.afterFieldHash:X8} ({(double)fieldResult.count / it.Value.fieldOccurrences[fieldResult.beforeFieldHash] * 100:0.0#}% probability)");
                         }
                     }
                 }

--- a/STUHashTool/Program.cs
+++ b/STUHashTool/Program.cs
@@ -219,10 +219,10 @@ namespace STUHashTool {
             foreach (KeyValuePair<uint, InstanceTally> it in instanceChangeTally) {
                 foreach (KeyValuePair<uint, List<CompareResult>> id in it.Value.resultDict) {
                     double instanceProbablility = id.Value.Count / it.Value.count * 100;
-                    Console.Out.WriteLine($"{it.Key:X} => {id.Key:X} ({instanceProbablility}% probability)");
+                    Console.Out.WriteLine($"{it.Key:X8} => {id.Key:X8} ({instanceProbablility}% probability)");
                     foreach (KeyValuePair<uint, List<FieldResult>> field in it.Value.fieldDict) {
                         foreach (FieldResult fieldResult in field.Value) {
-                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X} => {fieldResult.afterFieldHash:X} ({(double)fieldResult.count / it.Value.fieldOccurrences[fieldResult.beforeFieldHash] * 100:0.0#}% probability)");
+                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X8} => {fieldResult.afterFieldHash:X:X8} ({(double)fieldResult.count / it.Value.fieldOccurrences[fieldResult.beforeFieldHash] * 100:0.0#}% probability)");
                         }
                     }
                 }

--- a/STUHashTool/Program.cs
+++ b/STUHashTool/Program.cs
@@ -1,0 +1,233 @@
+﻿using STULib;
+using STULib.Impl.Version2HashComparer;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace STUHashTool {
+    public class InstanceTally {
+        public uint count;
+        public Dictionary<uint, uint> fieldOccurances;
+        public Dictionary<uint, List<CompareResult>> resultDict;
+        public Dictionary<uint, List<FieldResult>> fieldDict;
+
+        public FieldResult getField(uint before, uint after) {
+            foreach (FieldResult f in fieldDict[before]) {
+                if (f.afterFieldHash == after) {
+                    return f;
+                }
+            }
+            return null;
+        }
+    }
+
+    public class FieldResult {
+        public uint beforeFieldHash;
+        public uint afterFieldHash;
+        public uint count;
+    }
+
+    public class CompareResult {
+        public uint beforeInstanceHash;
+        public uint afterInstanceHash;
+        public List<FieldCompareResult> fields;
+    }
+
+    public class FieldCompareResult {
+        public uint beforeFieldHash;
+        public uint afterFieldHash;
+
+    }
+    class Program {
+        private static ISTU file1STU;
+        private static ISTU file2STU;
+
+        static bool ArraysEqual<T>(T[] a1, T[] a2) {
+            if (ReferenceEquals(a1, a2))
+                return true;
+
+            if (a1 == null || a2 == null)
+                return false;
+
+            if (a1.Length != a2.Length)
+                return false;
+
+            EqualityComparer<T> comparer = EqualityComparer<T>.Default;
+            for (int i = 0; i < a1.Length; i++) {
+                if (!comparer.Equals(a1[i], a2[i])) return false;
+            }
+            return true;
+        }
+
+        static void Main(string[] args) {
+            // usage:
+            // single file: file {before file path} {after file path}
+            // iter files in dir: dir {before file directory} {after file directory}
+
+            // todo: cleanup
+
+            if (args.Length < 3) {
+                Console.Out.WriteLine("usage:");
+                Console.Out.WriteLine("single file: file {before file path} {after file path}");
+                Console.Out.WriteLine("iter files in dir: dir {before file directory} {after file directory}");
+                return;
+            }
+            List<string> files1 = new List<string>();
+            List<string> files2 = new List<string>();
+            string directory1 = "";
+            string directory2 = "";
+            string mode = args[0];
+            if (mode == "file") {
+                directory1 = Path.GetDirectoryName(args[1]);
+                directory2 = Path.GetDirectoryName(args[2]);
+                files1.Add(Path.GetFileName(args[1]));
+                files2.Add(Path.GetFileName(args[2]));
+            } else if (mode == "dir") {
+                directory1 = args[1];
+                directory2 = args[2];
+                foreach (string f in Directory.GetFiles(args[1], "*", SearchOption.TopDirectoryOnly)) {
+                    files1.Add(Path.GetFileName(f));
+                }
+                foreach (string f in Directory.GetFiles(args[2], "*", SearchOption.TopDirectoryOnly)) {
+                    files2.Add(Path.GetFileName(f));
+                }
+            } else if (mode == "dir-rec") {
+                // todo: recurse over every type
+                throw new NotImplementedException();
+            }
+
+            List<string> both = files2.Intersect(files1).ToList();
+            List<CompareResult> results = new List<CompareResult>();
+
+            foreach (string file in both) {
+                string file1 = Path.Combine(directory1, file);
+                string file2 = Path.Combine(directory2, file);
+                using (Stream file1Stream = File.Open(file1, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                    using (Stream file2Stream = File.Open(file2, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                        file1STU = ISTU.NewInstance(file1Stream, uint.MaxValue, typeof(Version2Comparer));
+                        Version2Comparer file1STU2 = (Version2Comparer)file1STU;
+
+                        file2STU = ISTU.NewInstance(file2Stream, uint.MaxValue, typeof(Version2Comparer));
+                        Version2Comparer file2STU2 = (Version2Comparer)file2STU;
+
+                        foreach (STULib.Impl.Version2HashComparer.InstanceData instance1 in file1STU2.instanceDiffData) {
+                            foreach (STULib.Impl.Version2HashComparer.InstanceData instance2 in file2STU2.instanceDiffData) {
+                                // Console.Out.WriteLine($"Trying {instance1.hash:X}:{instance2.hash:X}");
+                                if (instance1.fields.Length != instance2.fields.Length) {
+                                    // Console.Out.WriteLine($"{instance1.hash:X} != {instance2.hash:X}, different field count");
+                                    continue;
+                                }
+
+                                if (instance1.size != instance2.size) {
+                                    // Console.Out.WriteLine($"{instance1.hash:X} != {instance2.hash:X}, different size");
+                                    continue;
+                                }
+
+                                if (file1STU2.instanceDiffData.Length != file2STU2.instanceDiffData.Length) {
+                                    // Console.Out.WriteLine($"{instance1.hash:X} != {instance2.hash:X}, can't verify due to different instance count");
+                                    continue;
+                                }
+
+                                if (instance1.fields.Length != instance2.fields.Length) {
+                                    // Console.Out.WriteLine($"{instance1.hash:X} != {instance2.hash:X}, different field count");
+                                    continue;
+                                }
+
+                                if (file1STU2.instanceDiffData.Length == 1 || file2STU2.instanceDiffData.Length == 1) {
+                                    // Console.Out.WriteLine($"{instance1.hash:X} is probably {instance2.hash:X}, only one instance");
+                                } else {
+                                    // Console.Out.WriteLine($"{instance1.hash:X} might be {instance2.hash:X}");
+                                }
+
+                                results.Add(new CompareResult { beforeInstanceHash = instance1.hash, afterInstanceHash = instance2.hash, fields = new List<FieldCompareResult>() });
+
+                                foreach (FieldData field1 in instance1.fields) {
+                                    foreach (FieldData field2 in instance2.fields) {
+                                        if (field1.size != field2.size) {
+                                            // Console.Out.WriteLine($"\t{field1.hash:X} != {field2.hash:X}, difference field size");
+                                            continue;
+                                        }
+
+                                        if (ArraysEqual(field1.sha1, field2.sha1)) {
+                                            // Console.Out.WriteLine($"\t{field1.hash:X} might be {field2.hash:X}, same sha1");
+                                            results.Last().fields.Add(new FieldCompareResult { beforeFieldHash = field1.hash, afterFieldHash = field2.hash });
+                                        }
+
+                                        if (field1.demangle_sha1 != null || field2.demangle_sha1 != null) {
+                                            if (ArraysEqual(field1.demangle_sha1, field2.demangle_sha1)) {
+                                                // Console.Out.WriteLine($"\t{field1.hash:X} might be {field2.hash:X}, same demangle sha1");
+                                                results.Last().fields.Add(new FieldCompareResult { beforeFieldHash = field1.hash, afterFieldHash = field2.hash });
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                }
+            }
+            Dictionary<uint, InstanceTally> instanceChangeTally = new Dictionary<uint, InstanceTally>();
+            foreach (CompareResult result in results) {
+                if (!instanceChangeTally.ContainsKey(result.beforeInstanceHash)) {
+                    instanceChangeTally[result.beforeInstanceHash] = new InstanceTally { count = 1, resultDict = new Dictionary<uint, List<CompareResult>>(), fieldDict = new Dictionary<uint, List<FieldResult>>() };
+                    instanceChangeTally[result.beforeInstanceHash].resultDict[result.afterInstanceHash] = new List<CompareResult> { result };
+                    instanceChangeTally[result.beforeInstanceHash].fieldOccurances = new Dictionary<uint, uint>();
+                    foreach (FieldCompareResult d in result.fields) {
+                        if (instanceChangeTally[result.beforeInstanceHash].fieldDict.ContainsKey(d.beforeFieldHash)) {
+                            instanceChangeTally[result.beforeInstanceHash].fieldOccurances[d.beforeFieldHash]++;
+                            FieldResult f = instanceChangeTally[result.beforeInstanceHash].getField(d.beforeFieldHash, d.afterFieldHash);
+                            if (f != null) {
+                                f.count++;
+                            } else {
+                                instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash].Add(new FieldResult { beforeFieldHash = d.beforeFieldHash, afterFieldHash = d.afterFieldHash, count = 1 });
+                            }
+
+                        } else {
+                            instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash] = new List<FieldResult>();
+                            instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash].Add(new FieldResult { beforeFieldHash = d.beforeFieldHash, afterFieldHash = d.afterFieldHash, count = 1 });
+                            instanceChangeTally[result.beforeInstanceHash].fieldOccurances[d.beforeFieldHash] = 1;
+                        }
+                    }
+                } else {
+                    instanceChangeTally[result.beforeInstanceHash].count++;
+                    if (!instanceChangeTally[result.beforeInstanceHash].resultDict.ContainsKey(result.afterInstanceHash)) {
+                        instanceChangeTally[result.beforeInstanceHash].resultDict[result.afterInstanceHash] = new List<CompareResult> { };
+                    }
+                    instanceChangeTally[result.beforeInstanceHash].resultDict[result.afterInstanceHash].Add(result);
+
+                    foreach (FieldCompareResult d in result.fields) {
+                        if (instanceChangeTally[result.beforeInstanceHash].fieldDict.ContainsKey(d.beforeFieldHash)) {
+                            instanceChangeTally[result.beforeInstanceHash].fieldOccurances[d.beforeFieldHash]++;
+                            FieldResult f = instanceChangeTally[result.beforeInstanceHash].getField(d.beforeFieldHash, d.afterFieldHash);
+                            if (f != null) {
+                                f.count++;
+                            } else {
+                                instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash].Add(new FieldResult { beforeFieldHash = d.beforeFieldHash, afterFieldHash = d.afterFieldHash, count = 1 });
+                            }
+
+                        } else {
+                            instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash] = new List<FieldResult>();
+                            instanceChangeTally[result.beforeInstanceHash].fieldDict[d.beforeFieldHash].Add(new FieldResult { beforeFieldHash = d.beforeFieldHash, afterFieldHash = d.afterFieldHash, count = 1 });
+                            instanceChangeTally[result.beforeInstanceHash].fieldOccurances[d.beforeFieldHash] = 1;
+                        }
+                    }
+                }
+            }
+            foreach (KeyValuePair<uint, InstanceTally> it in instanceChangeTally) {
+                foreach (KeyValuePair<uint, List<CompareResult>> id in it.Value.resultDict) {
+                    double instanceProbablility = id.Value.Count / it.Value.count * 100;
+                    Console.Out.WriteLine($"{it.Key:X} => {id.Key:X} ({instanceProbablility}% probability)");
+                    foreach (KeyValuePair<uint, List<FieldResult>> field in it.Value.fieldDict) {
+                        foreach (FieldResult fieldResult in field.Value) {
+                            Console.Out.WriteLine($"\t{fieldResult.beforeFieldHash:X} => {fieldResult.afterFieldHash:X} ({(double)fieldResult.count / it.Value.fieldOccurances[fieldResult.beforeFieldHash] * 100:0.0#}% probability)");
+                        }
+                    }
+                }
+            }
+            Debugger.Break();
+        }
+    }
+}

--- a/STUHashTool/Properties/AssemblyInfo.cs
+++ b/STUHashTool/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("STUHashTool")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("STUHashTool")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fb874758-ab99-4526-a035-8e6da1252822")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/STUHashTool/STUHashTool.csproj
+++ b/STUHashTool/STUHashTool.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FB874758-AB99-4526-A035-8E6DA1252822}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>STUHashTool</RootNamespace>
+    <AssemblyName>STUHashTool</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CASCExplorer\CascLib\CascLib.csproj">
+      <Project>{e08e1e48-6585-4137-8405-661c62c10713}</Project>
+      <Name>CascLib</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OWLib\OWLib.csproj">
+      <Project>{353c0d05-c505-4df4-909e-624fd94a7d3b}</Project>
+      <Name>OWLib</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\STULib\STULib.csproj">
+      <Project>{996012b0-3693-4642-ac44-5aa8865ee44a}</Project>
+      <Name>STULib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/STULib/ISTU.cs
+++ b/STULib/ISTU.cs
@@ -11,8 +11,8 @@ using System.Diagnostics;
 
 namespace STULib {
     public abstract class ISTU : IDisposable {
-        internal static Dictionary<uint, Type> instanceTypes;
-        internal static Dictionary<Type, string> instanceNames;
+        protected internal static Dictionary<uint, Type> instanceTypes;
+        protected internal static Dictionary<Type, string> instanceNames;
 
         internal static bool CheckCompatVersion(FieldInfo field, uint buildVersion) {
             IEnumerable<BuildVersionRangeAttribute> buildVersionRanges = field.GetCustomAttributes<BuildVersionRangeAttribute>();
@@ -30,7 +30,7 @@ namespace STULib {
             return parent.Concat(type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)).ToArray();
         }
 
-        internal static void LoadInstanceTypes() {
+        protected internal static void LoadInstanceTypes() {
             instanceTypes = new Dictionary<uint, Type>();
             instanceNames = new Dictionary<Type, string>();
 
@@ -90,9 +90,12 @@ namespace STULib {
             return null;
         }
 
-        public static ISTU NewInstance(Stream stream, uint owVersion) {
+        public static ISTU NewInstance(Stream stream, uint owVersion, Type type = null) {
             long pos = stream.Position;
             using (BinaryReader reader = new BinaryReader(stream, Encoding.Default, true)) {
+                if (type != null) {
+                    return (ISTU)Activator.CreateInstance(type, stream, owVersion);
+                }
                 if (Version1.IsValidVersion(reader)) {
                     stream.Position = pos;
                     return new Version1(stream, owVersion);

--- a/STULib/Impl/Version2HashComparer.cs
+++ b/STULib/Impl/Version2HashComparer.cs
@@ -1,0 +1,174 @@
+﻿using OWLib;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using static STULib.Types.Generic.Common;
+using static STULib.Types.Generic.Version2;
+
+namespace STULib.Impl.Version2HashComparer {
+    public class InstanceData {
+        public FieldData[] fields;
+        public uint hash;
+        public uint size;
+    }
+    public class FieldData {
+        public byte[] sha1;
+        public byte[] demangle_sha1;
+        public uint hash;
+        public uint size;
+    }
+
+    class FakeGUID : IDemangleable {
+        // [STUField(STUVersionOnly = new uint[] { 1 }, IgnoreVersion = new[] { 0xc41B27A5 })]
+        private ulong Padding = ulong.MaxValue;
+
+        // [STUField(0xDEADBEEF)] // DUMMY
+        public ulong Key;
+
+        public static implicit operator long(FakeGUID i) {
+            return (long)i.Key;
+        }
+
+        public static implicit operator ulong(FakeGUID i) {
+            return i.Key;
+        }
+
+        public new string ToString() {
+            return $"{GUID.LongKey(Key):X12}.{GUID.Type(Key):X3}" + (GUID.IsMangled(Key) ? " (Mangled)" : "");
+        }
+
+        public ulong[] GetGUIDs() {
+            return new[] {
+                    Key
+                };
+        }
+
+        public ulong[] GetGUIDXORs() {
+            return new[] {
+                    Padding
+                };
+        }
+
+        public void SetGUIDs(ulong[] GUIDs) {
+            if (GUIDs?.Length > 0) {
+                Key = GUIDs[0];
+            }
+        }
+    }
+    class FakeInstanceType : STUInstance { }
+
+    public class Version2Comparer : Version2 {
+        public InstanceData[] instanceDiffData;
+
+        public Version2Comparer(Stream stuStream, uint owVersion) : base(stuStream, owVersion) {
+        }
+
+        public string GetByteString(byte[] bytes) {
+            if (bytes != null) {
+                return Convert.ToBase64String(bytes);
+            }
+            return "null";
+        }
+
+        protected FieldData[] FakeReadInstance(Type instanceType, STUInstanceField[] writtenFields, BinaryReader reader,
+            int size) {
+            MemoryStream sandbox = new MemoryStream(size);
+            sandbox.Write(reader.ReadBytes(size), 0, size);
+            sandbox.Position = 0;
+            using (BinaryReader sandboxedReader = new BinaryReader(sandbox, Encoding.UTF8, false)) {
+                object instance = Activator.CreateInstance(instanceType);
+                return InitializeObject(instance, instanceType, writtenFields, sandboxedReader) as FieldData[];
+            }
+        }
+
+        protected override void ReadInstanceData(long offset) {
+            stream.Position = offset;
+            GetHeaderCRC();
+            stream.Position = offset;
+            using (BinaryReader reader = new BinaryReader(stream, Encoding.UTF8, true)) {
+                if (instanceTypes == null) {
+                    LoadInstanceTypes();
+                }
+
+                if (ReadHeaderData(reader)) {
+                    if (instanceTypes == null) {
+                        LoadInstanceTypes();
+                    }
+
+                    long stuOffset = header.Offset;
+                    instanceDiffData = new InstanceData[instanceInfo.Length];
+                    for (int i = 0; i < instanceInfo.Length; ++i) {
+                        stream.Position = stuOffset;
+                        stuOffset += instanceInfo[i].InstanceSize;
+
+                        // instances[i] = null;
+
+                        int fieldListIndex = reader.ReadInt32();
+
+                        
+                        FieldData[] fields = FakeReadInstance(typeof(FakeInstanceType), instanceFields[fieldListIndex], reader,
+                            (int)instanceInfo[i].InstanceSize - 4);
+                        instanceDiffData[i] = new InstanceData { size = instanceInfo[i].InstanceSize, hash = instanceInfo[i].InstanceChecksum, fields = fields };
+
+                        // }
+                    }
+
+                    //for (int i = 0; i < instanceInfo.Length; ++i) {
+                    //    if (instanceInfo[i].AssignInstanceIndex > -1 &&
+                    //        instanceInfo[i].AssignInstanceIndex < instances.Count) {
+                    //        SetField(instances[instanceInfo[i].AssignInstanceIndex],
+                    //            instanceInfo[i].AssignFieldChecksum, instances[i]);
+                    //    }
+                    //}
+                }
+            }
+        }
+
+        protected override object InitializeObject(object instance, Type type, STUInstanceField[] writtenFields, BinaryReader reader) {
+            Dictionary<uint, FieldInfo> fieldMap = CreateFieldMap(GetValidFields(type));
+            FieldData[] output = new FieldData[writtenFields.Length];
+            int i = 0;
+            foreach (STUInstanceField writtenField in writtenFields) {
+                // Console.Out.WriteLine("{0:X}", writtenField.FieldChecksum);
+                STUFieldAttribute element = new STUFieldAttribute { Checksum = writtenField.FieldChecksum };  // hmm
+
+                reader.BaseStream.Position += element.Padding;
+
+                long position = -1;
+                if (element?.ReferenceValue == true) {
+                    long offset = reader.ReadInt64();
+                    if (offset == 0) {
+                        continue;
+                    }
+                    position = reader.BaseStream.Position;
+                    reader.BaseStream.Position = offset;
+                }
+
+                long startPosition = reader.BaseStream.Position;
+                using (SHA1CryptoServiceProvider sha1 = new SHA1CryptoServiceProvider()) {
+                    byte[] demangleSha1 = null;
+                    if (writtenField.FieldSize == 8) {  // this might be a GUID, can't be sure
+                        FakeGUID f = new FakeGUID { Key = reader.ReadUInt64() };
+                        DemangleInstance(f, writtenField.FieldChecksum);
+                        demangleSha1 = sha1.ComputeHash(new byte[1] { (byte)f.Key });
+
+                        reader.BaseStream.Position = startPosition;
+                    }
+                    // Convert.ToBase64String(
+                    output[i] = new FieldData { sha1 = sha1.ComputeHash(reader.ReadBytes((int)writtenField.FieldSize)), size = writtenField.FieldSize, hash = writtenField.FieldChecksum, demangle_sha1 = demangleSha1 };
+
+                    // Console.Out.WriteLine($"{writtenField.FieldChecksum:X} : {GetByteString(output[i].sha1)} : {GetByteString(output[i].demangle_sha1)} ({writtenField.FieldSize} bytes)");
+                }
+
+                if (position > -1) {
+                    reader.BaseStream.Position = position;
+                }
+                i++;
+            }
+            return output;
+        }
+    }
+}

--- a/STULib/STULib.csproj
+++ b/STULib/STULib.csproj
@@ -53,6 +53,7 @@
     <Compile Include="BuildVersionRangeAttribute.cs" />
     <Compile Include="CRC64.cs" />
     <Compile Include="IDemangleable.cs" />
+    <Compile Include="Impl\Version2HashComparer.cs" />
     <Compile Include="Impl\Version2.cs" />
     <Compile Include="ISTU.cs" />
     <Compile Include="Impl\Version1.cs" />


### PR DESCRIPTION
I know you said work on overwatch/1.14 directly, but I'm looking for any feedback you might have. Pretty hacky, but seems to work most of the time. It gets more accurate the more files there are.

#### Times when this will go wrong:
* More fields being added, I currently just skip if the field count is different.
* Every occurrence of a field is changed, it won't be detected properly
  * It relies on the fact that only a few occurrences of the field should be changed in one patch, if most are changed then actual new field will have a low probability
* Also, I'm pretty sure that reference entries / detached variable lists don't work with this.

#### Usage:
* Single file: "file {before file} {after file}"
* Iter files in a single directory: "dir {before files directory} {after files directory}"
  * Single file should only be used for testing, the more files the better.

Essentially, the probability is just the percentage of fields that have stayed the same. 80% probability on the correct new hash means that 20% of the fields have a changed value. 