### PR TITLE
fix typo and add more functionality to extract-debug-type

### DIFF
--- a/DataTool/DataTool.csproj
+++ b/DataTool/DataTool.csproj
@@ -210,7 +210,7 @@
     <Compile Include="ToolLogic\List\ListGeneralUnlocks.cs" />
     <Compile Include="ToolLogic\List\ListHeroUnlocks.cs" />
     <Compile Include="ToolLogic\List\ListHighlights.cs" />
-    <Compile Include="ToolLogic\List\ListLoobox.cs" />
+    <Compile Include="ToolLogic\List\ListLootbox.cs" />
     <Compile Include="ToolLogic\List\ListResourceKeys.cs" />
     <Compile Include="ToolLogic\List\ListMaps.cs" />
     <Compile Include="ToolLogic\List\ListSubtitles.cs" />

--- a/DataTool/ToolLogic/Dump/DumpAllTheStuff.cs
+++ b/DataTool/ToolLogic/Dump/DumpAllTheStuff.cs
@@ -22,7 +22,7 @@ namespace DataTool.ToolLogic.Dump {
             new ListGameParams().Parse(GetFlagsForCommand(flags, "game-rulesets"));
             new ListGeneralUnlocks().Parse(GetFlagsForCommand(flags, "general-unlocks"));
             new ListHeroes().Parse(GetFlagsForCommand(flags, "heroes"));
-            new ListLoobox().Parse(GetFlagsForCommand(flags, "lootboxes"));
+            new ListLootbox().Parse(GetFlagsForCommand(flags, "lootboxes"));
             new ListMaps().Parse(GetFlagsForCommand(flags, "maps"));
             new ListReportResponses().Parse(GetFlagsForCommand(flags, "report-responses"));
             new DumpStrings().Parse(GetFlagsForCommand(flags, "strings", true));

--- a/DataTool/ToolLogic/Extract/Debug/ExtractDebugType.cs
+++ b/DataTool/ToolLogic/Extract/Debug/ExtractDebugType.cs
@@ -8,10 +8,10 @@ namespace DataTool.ToolLogic.Extract.Debug {
     [Tool("extract-debug-type", Description = "Extract type (debug)", CustomFlags = typeof(ExtractFlags), IsSensitive = true)]
     public class ExtractDebugType : ITool {
         public void Parse(ICLIFlags toolFlags) {
-            ExtractVoiceSets(toolFlags);
+            ExtractType(toolFlags);
         }
 
-        public void ExtractVoiceSets(ICLIFlags toolFlags) {
+        public void ExtractType(ICLIFlags toolFlags) {
             string basePath;
             if (toolFlags is ExtractFlags flags) {
                 basePath = flags.OutputPath;
@@ -22,8 +22,7 @@ namespace DataTool.ToolLogic.Extract.Debug {
             const string container = "DebugTypes";
             string path = Path.Combine(basePath, container);
             
-            WriteType(0x88, path);
-            //WriteType(0x43, path);
+            WriteType(Convert.ToUInt16(toolFlags.Positionals[3], 16), path);
         }
 
         public void WriteType(ushort type, string path) {

--- a/DataTool/ToolLogic/List/ListLootbox.cs
+++ b/DataTool/ToolLogic/List/ListLootbox.cs
@@ -9,7 +9,7 @@ using static DataTool.Helper.STUHelper;
 
 namespace DataTool.ToolLogic.List {
     [Tool("list-lootbox", Description = "List lootboxes", CustomFlags = typeof(ListFlags))]
-    public class ListLoobox : JSONTool, ITool {
+    public class ListLootbox : JSONTool, ITool {
         public void Parse(ICLIFlags toolFlags) {
             List<LootBox> lootboxes = GetLootboxes();
 


### PR DESCRIPTION
Now extract-debug-type can extract type provided as an argument instead of hardcoded one
Fixed typo Loobox -> Lootbox
