### PR TITLE
Fix of extract-lootbox NullReferenceException

### DIFF
--- a/DataTool/ToolLogic/Extract/ExtractLootbox.cs
+++ b/DataTool/ToolLogic/Extract/ExtractLootbox.cs
@@ -42,7 +42,7 @@ namespace DataTool.ToolLogic.Extract {
                 Combo.Find(info, 0x400000000001456);  // coin chest, todo
                 // 00000000315A.00C in 000000001456.003 (288230376151716950)
                 
-                foreach (STULootBoxShopCard lootboxShopCard in lootbox.m_shopCards) {
+                foreach (STULootBoxShopCard lootboxShopCard in lootbox.m_shopCards ?? System.Linq.Enumerable.Empty<STULootBoxShopCard>()) {
                     Combo.Find(info, lootboxShopCard.m_cardTexture);  // 004
                 }
 

--- a/DataTool/ToolLogic/Extract/ExtractLootbox.cs
+++ b/DataTool/ToolLogic/Extract/ExtractLootbox.cs
@@ -42,8 +42,10 @@ namespace DataTool.ToolLogic.Extract {
                 Combo.Find(info, 0x400000000001456);  // coin chest, todo
                 // 00000000315A.00C in 000000001456.003 (288230376151716950)
                 
-                foreach (STULootBoxShopCard lootboxShopCard in lootbox.m_shopCards ?? System.Linq.Enumerable.Empty<STULootBoxShopCard>()) {
-                    Combo.Find(info, lootboxShopCard.m_cardTexture);  // 004
+                if (lootbox.m_shopCards != null) {
+                    foreach (STULootBoxShopCard lootboxShopCard in lootbox.m_shopCards) {
+                        Combo.Find(info, lootboxShopCard.m_cardTexture);  // 004
+                    }
                 }
 
                 var context = new SaveLogic.Combo.SaveContext(info);


### PR DESCRIPTION
Lootbox called Unknown12 do not have shop cards which leads to an exception and as a result prevents the successful extraction.