### PR TITLE
effects model name should use GetNameIndex

### DIFF
--- a/DataTool/SaveLogic/Effect.cs
+++ b/DataTool/SaveLogic/Effect.cs
@@ -110,7 +110,7 @@ namespace DataTool.SaveLogic {
                     FindLogic.Combo.ModelAsset modelInfo = Info.m_models[rpceInfo.Model];
                     //writer.Write(rpceInfo.TextureDefiniton);
 
-                    writer.Write(Path.Combine("Models", modelInfo.GetName(), modelInfo.GetName() + ".owmdl"));
+                    writer.Write(Path.Combine("Models", modelInfo.GetName(), modelInfo.GetNameIndex() + ".owmdl"));
                 }
 
                 foreach (EffectParser.SVCEInfo svceInfo in effect.SVCEs) {


### PR DESCRIPTION
other places all use `modelInfo.GetNameIndex()`

https://github.com/overtools/OWLib/blob/ab08a937c236c0eb313cb6616e439c9125398b3b/DataTool/SaveLogic/Combo.cs#L350

https://github.com/overtools/OWLib/blob/ab08a937c236c0eb313cb6616e439c9125398b3b/DataTool/SaveLogic/Effect.cs#L74