### PR TITLE
improve and refactor help stuff a bit

### DIFF
--- a/DataTool/FindLogic/Combo.cs
+++ b/DataTool/FindLogic/Combo.cs
@@ -158,7 +158,11 @@ namespace DataTool.FindLogic {
             }
 
             public string GetName() {
-                return GetValidFilename(m_name, false) ?? GetFileName(m_GUID);
+                if (Program.Flags != null && Program.Flags.NoNames) {
+                    return GetFileName(m_GUID);
+                }
+
+                return GetValidFilename(m_name) ?? GetFileName(m_GUID);
             }
 
             public string GetNameIndex() {
@@ -166,7 +170,7 @@ namespace DataTool.FindLogic {
                 if (teResourceGUID.Type(m_GUID) == 0x118) return GetName();
                 if (teResourceGUID.Type(m_GUID) == 0x119) return GetName();
 
-                return GetValidFilename(m_name, false) ?? $"{m_GUID & 0xFFFFFFFFFFFF:X12}";
+                return GetName() ?? $"{m_GUID & 0xFFFFFFFFFFFF:X12}";
             }
         }
 

--- a/DataTool/Flag/CLIFlagAttribute.cs
+++ b/DataTool/Flag/CLIFlagAttribute.cs
@@ -19,4 +19,9 @@ namespace DataTool.Flag {
             return Flag;
         }
     }
+
+    public class FlagInfo : Attribute {
+        public string Name;
+        public string Description;
+    }
 }

--- a/DataTool/Flag/ICLIFlags.cs
+++ b/DataTool/Flag/ICLIFlags.cs
@@ -6,10 +6,16 @@ namespace DataTool.Flag {
         [CLIFlag(AllPositionals = true)]
         public string[] Positionals;
 
-        [CLIFlag(Flag = "h", Default = false, Help = "Print this help text", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
-        [Alias("help")]
-        public bool Help;
-
         public abstract bool Validate();
+    }
+
+    public abstract class IToolFlags : ICLIFlags {
+        [CLIFlag(Flag = "directory", Positional = 0, NeedsValue = true, Required = true, Help = "Overwatch Install Directory")]
+        public string OverwatchDirectory;
+
+        [CLIFlag(Flag = "mode", Positional = 1, NeedsValue = true, Required = true, Help = "Extraction Mode")]
+        public string Mode;
+
+        public abstract override bool Validate();
     }
 }

--- a/DataTool/Helper/IO.cs
+++ b/DataTool/Helper/IO.cs
@@ -12,11 +12,7 @@ using static DataTool.Program;
 
 namespace DataTool.Helper {
     public static class IO {
-        public static string GetValidFilename(string filename, bool force = true) {
-            if (Flags != null && Flags.NoNames && !force) {
-                return null;
-            }
-
+        public static string GetValidFilename(string filename) {
             if (filename == null) {
                 return null;
             }

--- a/DataTool/Helper/SpellCheckUtils.cs
+++ b/DataTool/Helper/SpellCheckUtils.cs
@@ -61,8 +61,9 @@ namespace DataTool.Helper {
         }
 
         public static void FillToolSpellDict(SymSpell symSpell) {
-            foreach (var type in GetTools(false)) {
+            foreach (var type in GetTools()) {
                 var attribute = type.GetCustomAttribute<ToolAttribute>();
+                if (attribute == null || attribute.IsSensitive) continue;
                 symSpell.CreateDictionaryEntry(attribute.Keyword.ToLower(), 1);
             }
         }

--- a/DataTool/ToolFlags.cs
+++ b/DataTool/ToolFlags.cs
@@ -4,13 +4,7 @@ using JetBrains.Annotations;
 
 namespace DataTool {
     [Serializable, UsedImplicitly]
-    public class ToolFlags : ICLIFlags {
-        [CLIFlag(Flag = "directory", Positional = 0, NeedsValue = true, Required = true, Help = "Overwatch Directory")]
-        public string OverwatchDirectory;
-
-        [CLIFlag(Flag = "mode", Positional = 1, NeedsValue = true, Required = true, Help = "Extraction Mode")]
-        public string Mode;
-
+    public class ToolFlags : IToolFlags {
         [CLIFlag(Default = false, Flag = "online", Help = "Allow downloading of corrupted files", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
         public bool Online;
 
@@ -22,9 +16,6 @@ namespace DataTool {
         [Alias("T")]
         public string SpeechLanguage;
 
-        [CLIFlag(Default = false, Flag = "graceful-exit", Help = "When enabled don't crash on invalid CMF Encryption", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
-        public bool GracefulExit;
-
         [CLIFlag(Default = true, Flag = "cache", Help = "Cache Index files from CDN", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
         public bool UseCache;
 
@@ -32,12 +23,8 @@ namespace DataTool {
         // ReSharper disable once InconsistentNaming
         public bool CacheCDNData;
 
-        [CLIFlag(Default = false, Flag = "validate-cache", Help = "Validate files from CDN", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
-        public bool ValidateCache;
-
         [CLIFlag(Default = false, Flag = "quiet", Help = "Suppress majority of output messages", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
         [Alias("q")]
-        [Alias("silent")]
         public bool Quiet;
 
         [CLIFlag(Default = false, Flag = "string-guid", Help = "Returns all strings as their GUID instead of their value", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"}, Hidden = true)]
@@ -75,7 +62,7 @@ namespace DataTool {
         [Alias("argd")]
         public bool DeleteArgs;
 
-        [CLIFlag(Default = false, Flag = "no-names", Help = "Don't use names for textures", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
+        [CLIFlag(Default = false, Flag = "no-names", Help = "Don't use names for textures", Hidden = true, Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
         public bool NoNames;
 
         [CLIFlag(Default = false, Flag = "canonical-names", Help = "Only use canonical names", Hidden = true, Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
@@ -92,6 +79,10 @@ namespace DataTool {
 
         [CLIFlag(Default = false, Flag = "allow-manifest-fallback", Help = "Allows falling back to older versions if manfiest doesn't exist", Hidden = true, Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
         public bool TryManifestFallback;
+
+        [CLIFlag(Flag = "h", Default = false, Help = "Print this help text", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
+        [Alias("help")]
+        public bool Help;
 
         public override bool Validate() => true;
     }

--- a/DataTool/ToolLogic/Extract/ExtractFlags.cs
+++ b/DataTool/ToolLogic/Extract/ExtractFlags.cs
@@ -4,8 +4,9 @@ using JetBrains.Annotations;
 
 namespace DataTool.ToolLogic.Extract {
     [Serializable, UsedImplicitly]
-    public class ExtractFlags : ICLIFlags {
-        [CLIFlag(Flag = "out-path", NeedsValue = true, Help = "Output path", Positional = 2, Required = true)]
+    [FlagInfo(Name = "Extract", Description = "Flags for extracting data. These apply to all extract-* modes.")]
+    public class ExtractFlags : IToolFlags {
+        [CLIFlag(Flag = "out-path", NeedsValue = true, Help = "Output path to save data", Positional = 2, Required = true)]
         public string OutputPath;
 
         [CLIFlag(Default = "tif", NeedsValue = true, Flag = "convert-textures-type", Help = "Texture output type", Valid = new[] {"dds", "tif", "png"})]

--- a/DataTool/ToolLogic/List/ListFlags.cs
+++ b/DataTool/ToolLogic/List/ListFlags.cs
@@ -4,7 +4,8 @@ using JetBrains.Annotations;
 
 namespace DataTool.ToolLogic.List {
     [Serializable, UsedImplicitly]
-    public class ListFlags : ICLIFlags {
+    [FlagInfo(Name = "List", Description = "Flags for listing data. These generally apply to list-* and dump-* commands.")]
+    public class ListFlags : IToolFlags {
         [CLIFlag(Default = false, Flag = "json", Help = "Output JSON to stderr", Parser = new[] {"DataTool.Flag.Converter", "CLIFlagBoolean"})]
         public bool JSON;
 


### PR DESCRIPTION
* Simplifies the help output and condenses it a bit
* Shows flags per flag type instead of per mode type (dump and list have the same flags)
* Removed validate cache and graceful exit as they do nothing
* removed silent arg as it's not really needed? -q is pretty standard
* Moved Directory and Mode flags/args to its own interface that all other flags inhereit. This seems to work fine in testing (to my surprise). This allows for mode specific help to work correctly. previously when listing extract specific help it would only do `DataToo.exe [--outpath=]` as it only had context of the Extract Flags and the Mode/Directory is part of ToolFlags which are completely unrelated. Now all modes have the Mode/Directory flags so they are included in the help and seems to cause no issues.