### PR TITLE
Documentation fixes in owm-formats

### DIFF
--- a/DataTool/DataTool.csproj
+++ b/DataTool/DataTool.csproj
@@ -5,7 +5,7 @@
         <LangVersion>default</LangVersion>
         <PlatformTarget>x64</PlatformTarget>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <Version>2.2.0.0</Version>
+        <Version>2.3.0.0</Version>
         <Configurations>Debug;Release;ReleasePublish;DebugPublish</Configurations>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'DebugPublish' ">

--- a/TankView/TankView.csproj
+++ b/TankView/TankView.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <PlatformTarget>x64</PlatformTarget>
     <NoWarn>CA1416</NoWarn>
-    <Version>2.2.0.0</Version>
+    <Version>2.3.0.0</Version>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' OR '$(Configuration)' == 'ReleasePublish' ">

--- a/owm-formats/owmap.txt
+++ b/owm-formats/owmap.txt
@@ -42,7 +42,7 @@ light:
     quaternion rotation;
     enum { point, spot } type;
     float fov;
-    vector4 color;
+    vector color;
     float intensity;
     uint64 projection_guids[2];
 

--- a/owm-formats/owmdl.txt
+++ b/owm-formats/owmdl.txt
@@ -21,7 +21,7 @@ bone:
     uint16 parent_index;
     vector position;
     vector scale;
-    quaternion rotation;
+    vector rotationEuler;
 
 mesh:
     string mesh;

--- a/owm-formats/owmdl.txt
+++ b/owm-formats/owmdl.txt
@@ -7,10 +7,10 @@ owmdl:
     uint16 version_minor = 0;
     string model_look_file_name;
     string model_name;
-    uint64 model_guid;
+    uint32 model_guid;
     uint16 bone_count;
-    uint16 mesh_count;
-    uint16 hardpoint_count;
+    uint32 mesh_count;
+    uint32 hardpoint_count;
 
     bone bones[bone_count];
     mesh meshes[mesh_count];
@@ -38,7 +38,7 @@ mesh:
     uint16 bone_index[bone_count][vertex_count];
     float bone_weight[bone_count][vertex_count];
     vector4 color[2][vertex_count];
-    uint32 index[index_count];
+    uint32 index[index_count][3];
 
 hardpoint:
     string name;


### PR DESCRIPTION
I came across a few errors while parsing owentity, owmap and owmdl.
These formats correspond to the code in TankLib properly now.